### PR TITLE
Edit sticky auth kristie

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,8 @@
-REACT_APP_API_URL=https://shielded-wildwood-05412.herokuapp.com/
+<!-- for heroku, use in main -->
+
+<!-- REACT_APP_API_URL=https://shielded-wildwood-05412.herokuapp.com/ -->
+
+
+<!-- for local - use in dev -->
+
+REACT_APP_API_URL=http://127.0.0.1:8000/

--- a/src/.env
+++ b/src/.env
@@ -1,1 +1,0 @@
-REACT_APP_API_URL=https://shielded-wildwood-05412.herokuapp.com/

--- a/src/components/LoginForm/LoginForm.jsx
+++ b/src/components/LoginForm/LoginForm.jsx
@@ -41,6 +41,7 @@ const handleSubmit = async (event) => {
         window.localStorage.setItem("token", data.token);    
         window.localStorage.setItem("username", credentials.username);
         window.localStorage.setItem("id", data.id);
+
         if (data.token===undefined) {
           console.log("invalid credentials")
           return (
@@ -50,7 +51,23 @@ const handleSubmit = async (event) => {
             </>
           )
         }
+
         else {
+          const userResponse = await fetch(
+            `${process.env.REACT_APP_API_URL}users/${data.id}/`,
+            {
+              method: "get",
+              headers: {
+                Authorization: `Token ${data.token}`,
+              }
+            }
+          );
+          const userdata = await userResponse.json();
+          // console.log(userdata)
+
+          window.localStorage.setItem("is_approver", userdata.is_approver);
+          window.localStorage.setItem("is_shecodes_admin", userdata.is_shecodes_admin);
+          window.localStorage.setItem("is_superuser", userdata.is_superuser);
           navigate(`/profile-page/${data.id}`);  
         }
         } catch (err) {

--- a/src/components/StickyNoteCard/StickyNoteCard.jsx
+++ b/src/components/StickyNoteCard/StickyNoteCard.jsx
@@ -8,9 +8,18 @@ import Pencil from "../images/icons/edit-pencil-slant.png";
 function StickyNoteCard(props) {
     // or ProjectCard({ projectData })
     const token = window.localStorage.getItem("token");
-    const isUserLoggedin = !(token === null || token === undefined || token === "undefined")
+    const UserId = window.localStorage.getItem("id");
+    const SuperUser = window.localStorage.getItem("is_superuser");
+    const Admin = window.localStorage.getItem("is_shecodes_admin");
+    const Approver = window.localStorage.getItem("is_approver");
+   
+    const isAdmin = (Admin == true)
+    const isApprover = (Approver == true)
+    const isSuperUser = (SuperUser == true)
+    
     // const { id } = useParams();
     const { stickynoteData } = props;
+    const isOwner = (UserId == stickynoteData.owner)
 
     const handleSubmitApprove = async (event) => {
         event.preventDefault();
@@ -60,7 +69,7 @@ function StickyNoteCard(props) {
         }
       };
 
-    if (isUserLoggedin) {
+    if (isSuperUser || isAdmin || isApprover) {
     
     return (
        
@@ -68,14 +77,8 @@ function StickyNoteCard(props) {
            
     
             <div className="stickynote-card">
-             <p>{stickynoteData.win_comment}</p> 
+             <p>{stickynoteData.win_comment}</p>
 
-             <Link to={`/edit-sticky-note/win-wall/${stickynoteData.id}/`}>
-            <button className="icon-button">
-                <img src={Pencil} />
-            </button>
-            </Link>
-             
             <button type="submit" onClick={handleSubmitApprove} className="icon-button">
                 {/* Update StickyNote */}
                 <img src={Circle} />
@@ -83,7 +86,15 @@ function StickyNoteCard(props) {
             <button type="submit" onClick={handleSubmitArchive} className="icon-button">
                 {/* Update StickyNote */}
                 <img src={Bin} />
+            </button> 
+
+             <Link to={`/edit-sticky-note/win-wall/${stickynoteData.id}/`}>
+            <button className="icon-button">
+                <img src={Pencil} />
             </button>
+            </Link>
+             
+            
             
         
             </div>
@@ -95,6 +106,32 @@ function StickyNoteCard(props) {
         </div>
     );
     }
+    else if (isOwner) {
+    
+        return (
+           
+            <div className="stickynote-area">
+               
+        
+                <div className="stickynote-card">
+                 <p>{stickynoteData.win_comment}</p> 
+    
+                 <Link to={`/edit-sticky-note/win-wall/${stickynoteData.id}/`}>
+                <button className="icon-button">
+                    <img src={Pencil} />
+                </button>
+                </Link>
+                 
+                </div>
+            
+    
+           
+            <div>
+            </div>
+            </div>
+        );
+        }
+
     else {
         return (
        

--- a/src/components/StickyNoteCard/StickyNoteCard.jsx
+++ b/src/components/StickyNoteCard/StickyNoteCard.jsx
@@ -13,9 +13,9 @@ function StickyNoteCard(props) {
     const Admin = window.localStorage.getItem("is_shecodes_admin");
     const Approver = window.localStorage.getItem("is_approver");
    
-    const isAdmin = (Admin == true)
-    const isApprover = (Approver == true)
-    const isSuperUser = (SuperUser == true)
+    const isAdmin = (Admin == 'true')
+    const isApprover = (Approver == 'true')
+    const isSuperUser = (SuperUser == 'true')
     
     // const { id } = useParams();
     const { stickynoteData } = props;

--- a/src/components/StickyNoteForm/StickyNoteForm.jsx
+++ b/src/components/StickyNoteForm/StickyNoteForm.jsx
@@ -4,7 +4,8 @@ import "./StickyNoteForm.css";
 
 function StickyNoteForm({ win_wallId }) {
   // State
-
+  const token = window.localStorage.getItem("token");
+  const isUserLoggedin = !(token === null || token === undefined || token === "undefined")
   const navigate = useNavigate();
   const [stickynote, setStickynote] = useState({
     win_comment: "",
@@ -40,14 +41,19 @@ let validateField = (win_comment, value) => {
     event.preventDefault();
 
     if(!stickynote.is_win_comment_valid) return;
+   let headers = {
+    "Content-Type": "application/json",
+   
+    };
+
+    if (isUserLoggedin) {
+      headers.Authorization = `Token ${token}`;
+    }
 
     try {
       const res = await fetch(`${process.env.REACT_APP_API_URL}sticky-notes/`, {
         method: "post",
-        headers: {
-          "Content-Type": "application/json",
-   
-        },
+        headers: headers,
         body: JSON.stringify({
           win_wall_id: win_wallId,
           win_comment: stickynote.win_comment,

--- a/src/pages/WinWallPage.jsx
+++ b/src/pages/WinWallPage.jsx
@@ -10,7 +10,14 @@ import Bin from "../components/images/icons/remove-circle.png";
 function WinWallPage() {
 
     const token = window.localStorage.getItem("token");
-    const isUserLoggedin = !(token === null || token === undefined || token === "undefined")
+    const SuperUser = window.localStorage.getItem("is_superuser");
+    const Admin = window.localStorage.getItem("is_shecodes_admin");
+    const Approver = window.localStorage.getItem("is_approver");
+   
+    const isAdmin = (Admin == true)
+    const isApprover = (Approver == true)
+    const isSuperUser = (SuperUser == true)
+
     const [WinwallData, setWinwallData] = useState();
     const { id } = useParams();
     useEffect(() => {
@@ -87,7 +94,7 @@ function WinWallPage() {
         }
       };
     
-      if (isUserLoggedin) {
+      if (isSuperUser || isAdmin || isApprover) {
 
     return (
         <div>

--- a/src/pages/WinWallPage.jsx
+++ b/src/pages/WinWallPage.jsx
@@ -14,9 +14,9 @@ function WinWallPage() {
     const Admin = window.localStorage.getItem("is_shecodes_admin");
     const Approver = window.localStorage.getItem("is_approver");
    
-    const isAdmin = (Admin == true)
-    const isApprover = (Approver == true)
-    const isSuperUser = (SuperUser == true)
+    const isAdmin = (Admin == 'true')
+    const isApprover = (Approver == 'true')
+    const isSuperUser = (SuperUser == 'true')
 
     const [WinwallData, setWinwallData] = useState();
     const { id } = useParams();
@@ -94,7 +94,7 @@ function WinWallPage() {
         }
       };
     
-      if (isSuperUser || isAdmin || isApprover) {
+    if (isSuperUser || isAdmin || isApprover) {
 
     return (
         <div>


### PR DESCRIPTION
If user is guest they can post and view

if user is logged in but not approver, admin or superuser they only see edit icon for their own sticky note

if user is superuser, admin, approver they can edit, approve, archive and bulk approve and archive sticky notes

user view:
<img width="1177" alt="image" src="https://user-images.githubusercontent.com/94447107/170834323-0a4c4b31-ef99-4797-bef9-7186426140c5.png">

superuser or admin or approver
<img width="373" alt="image" src="https://user-images.githubusercontent.com/94447107/170834814-9dee89bf-b16b-4bc5-8287-5f2f10c5b6d9.png">

we could potentially use a similar method if we want other pages to only show options for specific level of auth

![bitmoji](https://sdk.bitmoji.com/render/panel/de982485-6268-48af-857b-4dfe491cf102-1718c37c-5bac-4fa1-a081-40ffcb1da175-v1.png?transparent=1&palette=1&width=246)
